### PR TITLE
Fixed invisible editbox problem

### DIFF
--- a/release/NativeEditPlugin/scripts/NativeEditBox.cs
+++ b/release/NativeEditPlugin/scripts/NativeEditBox.cs
@@ -182,7 +182,8 @@ public class NativeEditBox : PluginMsgReceiver
 		if (!bNativeEditCreated || !this.Visible)
 			return;
 
-		this.SetVisible(hasFocus);
+		if(!hasFocus)
+			this.SetFocus(false);
 	}
 
 	private IEnumerator InitialzieOnNextFrame()
@@ -348,6 +349,8 @@ public class NativeEditBox : PluginMsgReceiver
 
 		if (!visibleOnCreate)
 			SetVisible(false);
+		else
+			Visible = true;
 
 		if (focusOnCreate)
 			SetFocus(true);


### PR DESCRIPTION
## Problem
The editbox becomes invisble by the below procedure in the native environment.
1. Call ` SetVisible(true) ` on NativeEditBox.cs ( ` Toggle Visible ` button in demo.scene calls this method)
2. Suspend app 
3. Resume app and the editbox becomes invisible.

After the problem occurred, the editbox can become visible by calling ` SetVisible(true) `  again.

## Cause
0. ` Visible ` variable is false for the first time.
https://github.com/moritanian/UnityNativeEdit/blob/506e84f7f3aa56c46775824087602ba340072fd1/release/NativeEditPlugin/scripts/NativeEditBox.cs#L94
1. ` Visible `  become true by calling ` SetVisible(true)` .
2.  ` OnApplicationFocus(false) ` is called and ` SetVisible(false) ` when the app is suspended.  
(If ` SetVisible(true) ` is not called explicitly (ex: click Toggle Visible button ), ` Visible ` is still false and ` SetVisible(false)` is not called in ` OnApplicationFocus ` . )
https://github.com/moritanian/UnityNativeEdit/blob/506e84f7f3aa56c46775824087602ba340072fd1/release/NativeEditPlugin/scripts/NativeEditBox.cs#L180-L187
3. When the app is resumed, ` OnApplicationFocus(true) ` is called, but ` SetActive(true) ` is not called because ` Visible ` is false. And so, the editbox remains invisible.

` OnApplicationFocus ` is added by [this pull request](https://github.com/YousicianGit/UnityNativeEdit/pull/23)

## Fix
- Set The ` Visible ` variable in ` NativeEditBox.cs `  true in  the creation .
- Unfocus the editbox when the app is suspended and do nothing when the app is resumed.

## Others
This is my first pull request and so, I would appreciate if you could point out mistake if any.
   

